### PR TITLE
Add granular style selection

### DIFF
--- a/module/umamusume/context.py
+++ b/module/umamusume/context.py
@@ -25,6 +25,7 @@ class CultivateContextDetail:
     learn_skill_selected: bool
     cultivate_finish: bool
     tactic_list: list[int]
+    tactic_actions: list
     debut_race_win: bool
     clock_use_limit: int
     clock_used: int
@@ -59,6 +60,7 @@ class CultivateContextDetail:
         self.learn_skill_selected = False
         self.cultivate_finish = False
         self.tactic_list = []
+        self.tactic_actions = []
         self.debut_race_win = False
         self.clock_use_limit = 0
         self.clock_used = 0
@@ -124,6 +126,7 @@ def build_context(task: UmamusumeTask, ctrl) -> UmamusumeContext:
             detail.user_provided_priority = False
         detail.learn_skill_blacklist = list(task.detail.learn_skill_blacklist or [])
         detail.tactic_list = list(task.detail.tactic_list or [])
+        detail.tactic_actions = list(getattr(task.detail, 'tactic_actions', []))
         detail.clock_use_limit = task.detail.clock_use_limit
         detail.learn_skill_threshold = task.detail.learn_skill_threshold
         detail.learn_skill_only_user_provided = task.detail.learn_skill_only_user_provided

--- a/module/umamusume/script/cultivate_task/info.py
+++ b/module/umamusume/script/cultivate_task/info.py
@@ -358,7 +358,29 @@ def script_info(ctx: UmamusumeContext):
         if title_text == TITLE[18] or title_text == TITLE[19]:  # "Tactics" or "Strategy"
             date = ctx.cultivate_detail.turn_info.date
             if date != -1:
-                if date <= 72:
+                target_tactic = None
+                if hasattr(ctx.cultivate_detail, 'tactic_actions') and ctx.cultivate_detail.tactic_actions:
+                    for action in ctx.cultivate_detail.tactic_actions:
+                        op = action.get('op')
+                        val = int(action.get('val', 0))
+                        val2 = int(action.get('val2', 0))
+                        tactic = int(action.get('tactic', 0))
+                        match = False
+                        if op == '=':
+                            if date == val: match = True
+                        elif op == '>':
+                            if date > val: match = True
+                        elif op == '<':
+                            if date < val: match = True
+                        elif op == 'range':
+                            if val < date < val2: match = True
+                        if match:
+                            target_tactic = tactic
+                            break
+
+                if target_tactic:
+                    ctx.ctrl.click_by_point(TACTIC_LIST[target_tactic - 1])
+                elif date <= 72:
                     ctx.ctrl.click_by_point(TACTIC_LIST[ctx.cultivate_detail.tactic_list[int((date - 1)/ 24)] - 1])
                 else:
                     ctx.ctrl.click_by_point(TACTIC_LIST[ctx.cultivate_detail.tactic_list[2] - 1])

--- a/module/umamusume/script/cultivate_task/race_handlers.py
+++ b/module/umamusume/script/cultivate_task/race_handlers.py
@@ -197,14 +197,34 @@ def script_cultivate_before_race(ctx: UmamusumeContext):
     date = ctx.cultivate_detail.turn_info.date
     if date != -1:
         tactic_check_point_list = [img[668, 480], img[668, 542], img[668, 600], img[668, 670]]
-        if date <= 72:
-            p_check_tactic = tactic_check_point_list[ctx.cultivate_detail.tactic_list[int((date - 1) / 24)] - 1]
-        else:
-            p_check_tactic = tactic_check_point_list[ctx.cultivate_detail.tactic_list[2] - 1]
-        if compare_color_equal(p_check_tactic, [170, 170, 170]):
-            ctx.ctrl.click_by_point(BEFORE_RACE_CHANGE_TACTIC)
-            return
+        target_tactic = None
 
+        if hasattr(ctx.cultivate_detail, 'tactic_actions') and ctx.cultivate_detail.tactic_actions:
+            for action in ctx.cultivate_detail.tactic_actions:
+                op = action.get('op')
+                val = int(action.get('val', 0))
+                val2 = int(action.get('val2', 0))
+                tactic = int(action.get('tactic', 0))
+                
+                match = False
+                if op == '=':
+                    if date == val: match = True
+                elif op == '>':
+                    if date > val: match = True
+                elif op == '<':
+                    if date < val: match = True
+                elif op == 'range':
+                    if val < date < val2: match = True
+                
+                if match:
+                    target_tactic = tactic
+                    break
+
+        if target_tactic:
+            p_check_tactic = tactic_check_point_list[target_tactic - 1]
+            if compare_color_equal(p_check_tactic, [170, 170, 170]):
+                ctx.ctrl.click_by_point(BEFORE_RACE_CHANGE_TACTIC)
+                return
     if p_check_skip[0] < 200 and p_check_skip[1] < 200 and p_check_skip[2] < 200:
         ctx.ctrl.click_by_point(BEFORE_RACE_START)
     else:

--- a/module/umamusume/task.py
+++ b/module/umamusume/task.py
@@ -14,6 +14,7 @@ class TaskDetail:
     learn_skill_list: list[list[str]]
     learn_skill_blacklist: list[str]
     tactic_list: list[int]
+    tactic_actions: list
     clock_use_limit: int
     learn_skill_threshold: int
     learn_skill_only_user_provided: bool
@@ -39,6 +40,7 @@ class TaskDetail:
     event_weights: dict
     scenario_config: ScenarioConfig
     do_tt_next: bool
+    stat_value_multiplier: list
 
 
 class EndTaskReason(Enum):
@@ -76,6 +78,7 @@ def build_task(task_execute_mode: TaskExecuteMode, task_type: int,
     td.learn_skill_list = attachment_data['learn_skill_list']
     td.learn_skill_blacklist = attachment_data['learn_skill_blacklist']
     td.tactic_list = attachment_data['tactic_list']
+    td.tactic_actions = attachment_data.get('tactic_actions', [])
     td.clock_use_limit = attachment_data['clock_use_limit']
     td.learn_skill_threshold = attachment_data['learn_skill_threshold']
     td.learn_skill_only_user_provided = attachment_data['learn_skill_only_user_provided']

--- a/module/umamusume/types.py
+++ b/module/umamusume/types.py
@@ -160,6 +160,7 @@ class CultivateContextDetail:
     learn_skill_selected: bool
     cultivate_finish: bool
     tactic_list: list[int]
+    tactic_actions: list
     debut_race_win: bool
     clock_use_limit: int
     clock_used: int


### PR DESCRIPTION
My pasas were either chugging clocks on pace or throwing mile races on late so I want the best of both worlds
this pr replaces the old year1/year2/year3 running style selection with a list of turn conditions you can make as many or as few of as you want - for example, this setup front runs the debut, runs late for all the mediums and longs I'm running and defaults to pace otherwise
<img width="1625" height="536" alt="{041E7B8E-EF7D-4831-A813-21C4BE75BB62}" src="https://github.com/user-attachments/assets/e13e38f3-68df-4eb8-83ff-fb2e92617c5e" />
new presets are initialized with three conditions equivalent to the old year-based ones, loading old presets converts them to the new system 
to more easily identify the correct turns, I've added both a table to look up turn numbers for dates (viewable by clicking the turn reference button)
<img width="1043" height="424" alt="{E7A34C4B-C792-4E41-8CEE-1B4553DCD614}" src="https://github.com/user-attachments/assets/419db102-6498-4be4-9b53-059c0700e36c" />
as well as adding turn numbers to the race selection
<img width="306" height="333" alt="{B00D4BDD-EB8C-42EB-A834-5C3FE80D1DA8}" src="https://github.com/user-attachments/assets/1c7f1c51-c7bd-43b3-b54d-918d4e868b48" />
