### PR TITLE
disconnect adb on exit

### DIFF
--- a/main.py
+++ b/main.py
@@ -304,7 +304,7 @@ if __name__ == '__main__':
         acquire_instance_lock()
     except Exception:
         pass
-    restart_adb_server()
+
     selected_device = None
     if os.environ.get("UAT_AUTORESTART", "0") == "1":
         try:


### PR DESCRIPTION
currently, after closing sweepy I can't start it again without manually restarting the adb server since it doesn't cleanly disconnect from adb on exit, so let's disconnect from adb on exit