### PR TITLE
Fix for saving/loading preset planned races

### DIFF
--- a/module/umamusume/script/cultivate_task/main_menu_handler.py
+++ b/module/umamusume/script/cultivate_task/main_menu_handler.py
@@ -259,48 +259,54 @@ def script_cultivate_main_menu(ctx: UmamusumeContext):
         handle_mant_rival_race(ctx, img)
 
     if not ctx.cultivate_detail.turn_info.parse_train_info_finish:
-        limit = int(getattr(ctx.cultivate_detail, 'rest_threshold', getattr(ctx.cultivate_detail, 'rest_treshold', getattr(ctx.cultivate_detail, 'fast_path_energy_limit', 48))))
-        if has_extra_race and not is_mant(ctx):
-            ctx.cultivate_detail.turn_info.parse_train_info_finish = True
-            return
-        if limit == 0:
-            energy = 100
+        # If a non-training operation is already decided (race/rest/trip/medic),
+        # execute it from main menu instead of entering training-select and bouncing back.
+        if (turn_operation is not None and
+                turn_operation.turn_operation_type != TurnOperationType.TURN_OPERATION_TYPE_TRAINING):
+            pass
         else:
-            from bot.conn.fetch import read_energy
-            energy = read_energy()
-            if energy == 0:
-                time.sleep(0.15)
-                energy = read_energy()
-        if is_mant(ctx) and energy <= limit:
-            ctx.cultivate_detail.turn_info.cached_energy = energy
-            if has_extra_race:
-                from module.umamusume.scenario.mant.inventory import has_energy_recovery
-                if has_energy_recovery(ctx):
-                    ctx.cultivate_detail.turn_info.energy_recovery_deferred = True
+            limit = int(getattr(ctx.cultivate_detail, 'rest_threshold', getattr(ctx.cultivate_detail, 'rest_treshold', getattr(ctx.cultivate_detail, 'fast_path_energy_limit', 48))))
+            if has_extra_race and not is_mant(ctx):
+                ctx.cultivate_detail.turn_info.parse_train_info_finish = True
+                return
+            if limit == 0:
+                energy = 100
             else:
-                from module.umamusume.scenario.mant.inventory import handle_energy_recovery
-                if handle_energy_recovery(ctx):
-                    energy = getattr(ctx.cultivate_detail.turn_info, 'cached_energy', energy)
-        if energy <= limit:
-            if getattr(ctx.cultivate_detail.turn_info, 'energy_recovery_deferred', False):
+                from bot.conn.fetch import read_energy
+                energy = read_energy()
+                if energy == 0:
+                    time.sleep(0.15)
+                    energy = read_energy()
+            if is_mant(ctx) and energy <= limit:
+                ctx.cultivate_detail.turn_info.cached_energy = energy
+                if has_extra_race:
+                    from module.umamusume.scenario.mant.inventory import has_energy_recovery
+                    if has_energy_recovery(ctx):
+                        ctx.cultivate_detail.turn_info.energy_recovery_deferred = True
+                else:
+                    from module.umamusume.scenario.mant.inventory import handle_energy_recovery
+                    if handle_energy_recovery(ctx):
+                        energy = getattr(ctx.cultivate_detail.turn_info, 'cached_energy', energy)
+            if energy <= limit:
+                if getattr(ctx.cultivate_detail.turn_info, 'energy_recovery_deferred', False):
+                    base_energy, _, _ = scan_energy(ctx.ctrl)
+                    ctx.cultivate_detail.turn_info.base_energy = base_energy
+                    ctx.ctrl.click_by_point(TO_TRAINING_SELECT)
+                    return
+                if should_use_team_sirius_recreation(ctx):
+                    if execute_team_sirius_recreation(ctx, trip_click_point=get_trip(ctx)):
+                        return
+                from module.umamusume.script.cultivate_task.helpers import should_use_pal_outing
+                if should_use_pal_outing(ctx):
+                    ctx.ctrl.click_by_point(get_trip(ctx))
+                    return
+                ctx.ctrl.click_by_point(CULTIVATE_REST)
+                return
+            else:
                 base_energy, _, _ = scan_energy(ctx.ctrl)
                 ctx.cultivate_detail.turn_info.base_energy = base_energy
                 ctx.ctrl.click_by_point(TO_TRAINING_SELECT)
                 return
-            if should_use_team_sirius_recreation(ctx):
-                if execute_team_sirius_recreation(ctx, trip_click_point=get_trip(ctx)):
-                    return
-            from module.umamusume.script.cultivate_task.helpers import should_use_pal_outing
-            if should_use_pal_outing(ctx):
-                ctx.ctrl.click_by_point(get_trip(ctx))
-                return
-            ctx.ctrl.click_by_point(CULTIVATE_REST)
-            return
-        else:
-            base_energy, _, _ = scan_energy(ctx.ctrl)
-            ctx.cultivate_detail.turn_info.base_energy = base_energy
-            ctx.ctrl.click_by_point(TO_TRAINING_SELECT)
-            return
 
     if turn_operation is not None:
         if turn_operation.turn_operation_type == TurnOperationType.TURN_OPERATION_TYPE_TRAINING:

--- a/web/src/components/TaskEditModal.vue
+++ b/web/src/components/TaskEditModal.vue
@@ -3620,7 +3620,12 @@ export default {
     },
     applyPresetRace: function () {
       this.selectedScenario = this.presetsUse.scenario || 1
-      this.extraRace = this.presetsUse.race_list
+      const presetRaceList = Array.isArray(this.presetsUse.race_list)
+        ? this.presetsUse.race_list
+        : (Array.isArray(this.presetsUse.extra_race_list) ? this.presetsUse.extra_race_list : [])
+      this.extraRace = presetRaceList
+        .map(raceId => Number(raceId))
+        .filter(raceId => Number.isFinite(raceId))
       this.expectSpeedValue = this.presetsUse.expect_attribute[0]
       this.expectStaminaValue = this.presetsUse.expect_attribute[1]
       this.expectPowerValue = this.presetsUse.expect_attribute[2]
@@ -4236,7 +4241,8 @@ export default {
         use_last_parents: this.useLastParents,
         override_insufficient_fans_forced_races: this.overrideInsufficientFansForcedRaces,
         scenario: this.selectedScenario,
-        race_list: this.extraRace,
+        race_list: this.extraRace.map(raceId => Number(raceId)).filter(raceId => Number.isFinite(raceId)),
+        extra_race_list: this.extraRace.map(raceId => Number(raceId)).filter(raceId => Number.isFinite(raceId)),
         skill_priority_list: skill_priority_list,
         skill_blacklist: skill_blacklist,
         event_weights: {
@@ -4452,7 +4458,8 @@ export default {
         use_last_parents: this.useLastParents,
         override_insufficient_fans_forced_races: this.overrideInsufficientFansForcedRaces,
         scenario: this.selectedScenario,
-        race_list: this.extraRace,
+        race_list: this.extraRace.map(raceId => Number(raceId)).filter(raceId => Number.isFinite(raceId)),
+        extra_race_list: this.extraRace.map(raceId => Number(raceId)).filter(raceId => Number.isFinite(raceId)),
         skill_priority_list: skill_priority_list,
         skill_blacklist: skill_blacklist,
         event_weights: {


### PR DESCRIPTION
## What changed
- Fixed preset race loading to support both `race_list` and `extra_race_list`.
- Normalized loaded race IDs to numeric values.
- Updated preset save/export to include both `race_list` and `extra_race_list` so planned races persist across different readers/paths.

## Why
Planned races selected in UI were not reliably preserved across save/export/load flows due to field-name mismatch between preset and task schemas.