### PR TITLE
fix: detect in-game decks by updating support_list mapping

### DIFF
--- a/data/support_list.json
+++ b/data/support_list.json
@@ -940,9 +940,9 @@
     "type": "Wisdom"
   },
   "20047": {
-    "name": "Unknown",
+    "name": "Tokai Teio",
     "rarity": "SR",
-    "type": "Unknown"
+    "type": "Stamina"
   },
   "20048": {
     "name": "Oguri Cap",
@@ -1660,9 +1660,9 @@
     "type": "Power"
   },
   "30097": {
-    "name": "Unknown",
+    "name": "Mr. C.B.",
     "rarity": "SSR",
-    "type": "Unknown"
+    "type": "Wisdom"
   },
   "30098": {
     "name": "Haru Urara",


### PR DESCRIPTION
## Summary
- Updated \data/support_list.json\ to correct support card mapping used for deck detection.
- Fixed an issue where existing in-game decks were not shown in the app.

## Linked issue
Closes #97

## Verification
- Confirmed deck detection now finds existing in-game decks.
